### PR TITLE
Deprecated `Model._meta.module_name` has been removed in Django 1.8

### DIFF
--- a/separated/views.py
+++ b/separated/views.py
@@ -86,6 +86,7 @@ class CsvResponseMixin(MultipleObjectMixin):
         try:
             model_name = opts.model_name
         except AttributeError:
+            # for Django < 1.6. Deprecated in 1.6 & removed in 1.8.
             model_name = opts.module_name
         return self.filename.format(
             model_name=model_name,

--- a/separated/views.py
+++ b/separated/views.py
@@ -83,7 +83,10 @@ class CsvResponseMixin(MultipleObjectMixin):
 
     def get_filename(self, model):
         opts = model._meta
-        model_name = getattr(opts, 'model_name', opts.module_name)
+        try:
+            model_name = opts.model_name
+        except AttributeError:
+            model_name = opts.module_name
         return self.filename.format(
             model_name=model_name,
         )


### PR DESCRIPTION
The deprecated `Model._meta.module_name` has been [removed in Django 1.8](https://docs.djangoproject.com/en/1.8/internals/deprecation/#deprecation-removed-in-1-8)