### PR TITLE
Add the ability to override the dialect to be used for generating the CSV

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,6 +79,13 @@ settings the ``filename`` attribute.  There is a corresponding
 By default, ``CsvView`` will output the headers as the first line.  If you
 want to suppress this behavior, set ``output_headers`` to ``False``.
 
+By defaultm ``csv.excel`` is used as the dialect. You can override the by setting
+the ``dialect`` attribute. For example::
+
+    class UserCsvView(CsvView):
+        model = User
+        dialect = csv.excel_tab
+
 separated.views.CsvResponseMixin
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/separated/views.py
+++ b/separated/views.py
@@ -38,6 +38,7 @@ class CsvResponseMixin(MultipleObjectMixin):
     columns = None
     output_headers = True
     filename = '{model_name}_list.csv'
+    dialect = csv.excel
 
     def render_to_response(self, context, **kwargs):
         queryset = context['object_list']
@@ -46,7 +47,7 @@ class CsvResponseMixin(MultipleObjectMixin):
             filename=self.get_filename(model),
         )
 
-        writer = csv.writer(response)
+        writer = csv.writer(response, dialect=self.dialect)
 
         if self.output_headers:
             writer.writerow(self.get_header_row(model))


### PR DESCRIPTION
I've added the ability to override the dialect to be used for generating the CSV. See the documentation.