### PR TITLE
Make `CsvResponseMixin` simpler

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -118,13 +118,14 @@ CsvView will forward the value of ``output_headers`` to the
 separated.views.CsvResponseMixin
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-A MultipleObjectMixin subclass that returns a ``CsvResponse``.
+A mixin which returns a ``CsvResponse``.
 
-This is useful in instances where you want to substitute BaseListView for a
-ListView of your own.  ``CsvResponseMixin`` supports all the behavior
+This is useful in instances where you want to render your own queryset as a
+CSV. ``CsvResponseMixin`` supports all the behavior
 mentioned in ``CsvView``, the only machinery you need to hook it up is a
 View class that calls ``render_to_response`` with a context that has a
-queryset available in the ``object_list`` key. ::
+queryset available in the ``queryset_variable_name`` key, ``object_list`` by
+default. ::
 
     class MyWeirdBaseListView(View):
         def get(self, request, *args, **kwargs):

--- a/separated/views.py
+++ b/separated/views.py
@@ -5,7 +5,7 @@ from email.header import Header
 import django
 from django.core.exceptions import ImproperlyConfigured
 from django.http import HttpResponse
-from django.views.generic.list import BaseListView, MultipleObjectMixin
+from django.views.generic.list import BaseListView
 
 from .utils import ColumnSerializer
 
@@ -25,18 +25,21 @@ class CsvResponse(HttpResponse):
         self['Content-Disposition'] = disposition
 
 
-class CsvResponseMixin(MultipleObjectMixin):
+class CsvResponseMixin(object):
     """
-    A ListView mixin that returns a CsvResponse.
+    A mixin that renders a queryset as a CsvResponse.
+
+    @ivar queryset_variable_name: Name of context variable to be rendered in CSV.
     """
     response_class = CsvResponse
+    queryset_variable_name = 'object_list'
     column_serializer_class = ColumnSerializer
     columns = None
     output_headers = True
     filename = '{model_name}_list.csv'
 
     def render_to_response(self, context, **kwargs):
-        queryset = context['object_list']
+        queryset = context[self.queryset_variable_name]
         model = queryset.model
         response = self.response_class(
             filename=self.get_filename(model),

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ def read_file(filename):
     with open(os.path.join(os.path.dirname(__file__), filename)) as f:
         return f.read()
 
+
 setup(
     name='django-separated',
     version='1.1.1.dev0',

--- a/testproject/testproject/models.py
+++ b/testproject/testproject/models.py
@@ -13,6 +13,7 @@ class Manufacturer(models.Model):
     def __str__(self):
         return self.name
 
+
 if python_2_unicode_compatible:
     Manufacturer = python_2_unicode_compatible(Manufacturer)
 else:


### PR DESCRIPTION
In order to be more useful, the `CsvResponseMixin` shouldn't inherit from `MultipleObjectMixin`. If it's based only on `object`, it can be used with any `View` in general.

Depends on #10.